### PR TITLE
Added support for PhysX Visual Debugger

### DIFF
--- a/physx/source/physxwebbindings/src/PhysXJs.idl
+++ b/physx/source/physxwebbindings/src/PhysXJs.idl
@@ -11,10 +11,11 @@ interface PxTopLevelFunctions {
     static PxControllerManager CreateControllerManager([Ref] PxScene scene, optional boolean lockingEnabled);
     static PxCooking CreateCooking(unsigned long version, [Ref] PxFoundation foundation, [Const, Ref] PxCookingParams scale);
     static PxFoundation CreateFoundation(unsigned long version, [Ref] PxDefaultAllocator allocator, [Ref] PxErrorCallback errorCallback);
-    static PxPhysics CreatePhysics(unsigned long version, [Ref] PxFoundation foundation, [Const, Ref] PxTolerancesScale params);
+    static PxPhysics CreatePhysics(unsigned long version, [Ref] PxFoundation foundation, [Const, Ref] PxTolerancesScale params, optional PxPvd pvd);
     static PxDefaultCpuDispatcher DefaultCpuDispatcherCreate(unsigned long numThreads);
     static boolean InitExtensions([Ref] PxPhysics physics);
     static PxCudaContextManager CreateCudaContextManager([Ref] PxFoundation foundation, [Const, Ref] PxCudaContextManagerDesc desc);
+    static PxPvd CreatePvd([Ref] PxFoundation foundation);
 
     static PxD6Joint D6JointCreate([Ref] PxPhysics physics, PxRigidActor actor0, [Ref] PxTransform localFrame0, PxRigidActor actor1, [Ref] PxTransform localFrame1);
     static PxDistanceJoint DistanceJointCreate([Ref] PxPhysics physics, PxRigidActor actor0, [Ref] PxTransform localFrame0, PxRigidActor actor1, [Ref] PxTransform localFrame1);
@@ -3249,4 +3250,42 @@ interface Vector_PxVehicleWheels {
     PxVehicleWheelsPtr data();
     unsigned long size();
     void push_back(PxVehicleWheels value);
+};
+
+[Prefix = "physx::", NoDelete] interface PxPvdTransport {
+    boolean connect();
+    void disconnect();
+    boolean isConnected();
+};
+
+interface SimplePvdTransport {
+    void SimplePvdTransport();
+    void send(long inBytes, long inLength);
+};
+SimplePvdTransport implements PxPvdTransport;
+
+[JSImplementation="SimplePvdTransport"]
+interface JSPvdTransport {
+    void JSPvdTransport();
+};
+JSPvdTransport implements SimplePvdTransport;
+
+enum PxPvdInstrumentationFlagEnum {
+    "PxPvdInstrumentationFlagEnum::eDEBUG",
+    "PxPvdInstrumentationFlagEnum::ePROFILE",
+    "PxPvdInstrumentationFlagEnum::eMEMORY",
+    "PxPvdInstrumentationFlagEnum::eALL"
+};
+
+[Prefix = "physx::"] interface PxPvdInstrumentationFlags
+{
+    void PxPvdInstrumentationFlags(octet flags);
+    boolean isSet(PxPvdInstrumentationFlagEnum flag);
+    void set(PxPvdInstrumentationFlagEnum flag);
+    void clear(PxPvdInstrumentationFlagEnum flag);
+};
+
+[Prefix = "physx::", NoDelete] interface PxPvd
+{
+    boolean connect([Ref] PxPvdTransport transport, [Ref] PxPvdInstrumentationFlags flags);
 };


### PR DESCRIPTION
Managed to get with hooked up with [PhysX Visual Debugger](https://gameworksdocs.nvidia.com/PhysX/4.1/documentation/physxguide/Manual/VisualDebugger.html). I used Websockify to proxy data from Browser -> PhysX Debugger _(`websockify 8090 127.0.0.1:5425`)_

![](https://i.gyazo.com/dff85c122fd701fcfe9b1029ff15e6c7.png)

### Dev notes:
**You HAVE to be using Profile/Debug build. As Release strips PVD code**

I'm not familiar with C++ code so if there's better way of doing things let me know.

I wasn't able to link `bool write(const uint8_t *inBytes, uint32_t inLength)` with WebIDL successfully. So had to proxy it through `send` not quite sure why... pointers?

Also Websocket/Websockify can get quite overwhelmed if a lot of data is sent (lots of object & high update rate). There might be a better solution with buffering data before the WASM->JS send call....

### Some example code:
```ts
let pvdPvd: PhysX.PxPvd = null;

if (debug) {
	console.warn(`⚠️ Make sure Profile/Debug PhysX build is used.`);

	pvdPvd = PhysX.PxTopLevelFunctions.CreatePvd(foundation);
	const pvdTransport = createPhysXDebugger();
	pvdPvd.connect(pvdTransport, new PhysX.PxPvdInstrumentationFlags(PhysX.PxPvdInstrumentationFlagEnum.DEBUG));
}

const physics = PhysX.PxTopLevelFunctions.CreatePhysics(version, foundation, new PhysX.PxTolerancesScale(), pvdPvd);
```

```ts
export const createPhysXDebugger = (host = 'localhost', port = 8090) => {
	const pvdTransport = new PhysX.JSPvdTransport();

	let socket: WebSocket;
	let queue = [];
	let connected = false;

	pvdTransport.connect = () => {
		socket = new WebSocket(`ws://${host}:${port}`, ['binary']);
		socket.onopen = () => {
			console.log('🔌 Connected to PhysX Debugger');

			// Send packets the debugger missed
			queue.forEach(data => socket.send(data));
			queue = [];

			connected = true;
		};

		return true;
	};

	pvdTransport.send = (inBytes, inLength) => {
		const data = PhysX.HEAPU8.slice(inBytes, inBytes + inLength);

		if (!connected) {
			queue.push(data);
		} else {
			socket.send(data);
		}

		return true;
	};

	return pvdTransport;
};
```